### PR TITLE
Add ONNX Export and MNN/TNN/ONNXRuntime C++ Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ If you find this work or code useful for your research, please use the following
 
 [FBA Matting](https://github.com/MarcoForte/FBA_Matting)
 
+## C++ Inference Demo  
+[MGMatting ONNXRuntime C++](https://github.com/DefTruth/lite.ai.toolkit/blob/main/lite/ort/cv/mg_matting.cpp) 、[MGMatting MNN C++](https://github.com/DefTruth/lite.ai.toolkit/blob/main/lite/mnn/cv/mnn_mg_matting.cpp) and [MGMatting TNN C++](https://github.com/DefTruth/lite.ai.toolkit/blob/main/lite/tnn/cv/tnn_mg_matting.cpp) from [lite.ai.toolkit](https://github.com/DefTruth/lite.ai.toolkit).
+
 ## Lisence
 Research only;
 

--- a/code-base/export_onnx.py
+++ b/code-base/export_onnx.py
@@ -1,0 +1,111 @@
+import toml
+import argparse
+import torch
+import utils
+import networks
+from utils import CONFIG
+
+if __name__ == '__main__':
+    import onnx
+    import onnxruntime as ort
+    from onnxsim import simplify
+
+    print('Torch Version: ', torch.__version__, "ONNX Version: ", onnx.__version__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', type=str, default='./config/MGMatting-DIM-100k.toml')
+    parser.add_argument('--checkpoint', type=str, default='./checkpoints/MGMatting-DIM-100k/latest_model.pth',
+                        help="path of checkpoint")
+    parser.add_argument('--output_path', type=str, default='./checkpoints/MGMatting-DIM-100k/latest_model.onnx',
+                        help="output path")
+    parser.add_argument("--dynamic", action="store_true", help="export ONNX with dynamic shape")
+    parser.add_argument("--simplify", action="store_true", help="export ONNX with simplify")
+    # Parse configuration
+    args = parser.parse_args()
+    print(args)
+    with open(args.config) as f:
+        utils.load_config(toml.load(f))
+
+    # Check if toml config file is loaded
+    if CONFIG.is_default:
+        raise ValueError("No .toml config loaded.")
+
+    # build model
+    model = networks.get_generator(encoder=CONFIG.model.arch.encoder, decoder=CONFIG.model.arch.decoder)
+    model.cpu()
+    print("Generate Model Done.")
+
+    # load checkpoint
+    checkpoint = torch.load(args.checkpoint, map_location=torch.device('cpu'))
+    model.load_state_dict(utils.remove_prefix_state_dict(checkpoint['state_dict']), strict=True)
+    print(f"Load {args.checkpoint} Done.")
+
+    # inference
+    model = model.eval()
+
+    image = torch.randn((1, 3, 512, 512), requires_grad=False)
+    mask = torch.randn((1, 1, 512, 512), requires_grad=False)
+    onnx_file_name = args.output_path
+    dynamic_axes = {
+        "image": {2: 'height', 3: 'width'},
+        "mask": {2: 'height', 3: 'width'},
+        "alpha_os1": {2: 'height', 3: 'width'},
+        "alpha_os4": {2: 'height', 3: 'width'},
+        "alpha_os8": {2: 'height', 3: 'width'},
+    }
+
+    # Export the model
+    if args.dynamic:
+        print('Export the dynamic onnx model ...')
+        torch.onnx.export(model,
+                          (image, mask),
+                          onnx_file_name,
+                          export_params=True,
+                          opset_version=12,
+                          do_constant_folding=True,
+                          input_names=["image", "mask"],
+                          output_names=["alpha_os1", "alpha_os4", "alpha_os8"],
+                          dynamic_axes=dynamic_axes)
+    else:
+        print('Export the static onnx model ...')
+        torch.onnx.export(model,
+                          (image, mask),
+                          onnx_file_name,
+                          export_params=True,
+                          opset_version=12,
+                          do_constant_folding=True,
+                          input_names=["image", "mask"],
+                          output_names=["alpha_os1", "alpha_os4", "alpha_os8"])
+
+    print("export onnx done.")
+    onnx_model = onnx.load(onnx_file_name)
+    onnx.checker.check_model(onnx_model)
+    print(onnx.helper.printable_graph(onnx_model.graph))
+
+    if args.dynamic:
+        model_simp, check = simplify(onnx_model,
+                                     check_n=3,
+                                     dynamic_input_shape=True,
+                                     input_shapes={"image": [1, 3, 512, 512],
+                                                   "mask": [1, 1, 512, 512]}
+                                     )
+    else:
+        model_simp, check = simplify(onnx_model,
+                                     check_n=3)
+
+    onnx.save(model_simp, onnx_file_name)
+    print(onnx.helper.printable_graph(model_simp.graph))
+    print("export onnx sim done.")
+
+    # test onnxruntime
+    ort_session = ort.InferenceSession(onnx_file_name)
+
+    for o in ort_session.get_inputs():
+        print(o)
+
+    for o in ort_session.get_outputs():
+        print(o)
+
+    """
+    PYTHONPATH=. python3 ./export_onnx.py --dynamic --simplify --config ./config/MGMatting-DIM-100k.toml --checkpoint ./checkpoints/MGMatting-DIM-100k/latest_model.pth --output_path ./checkpoints/MGMatting-DIM-100k/latest_model.onnx
+    """

--- a/code-base/infer_onnx.py
+++ b/code-base/infer_onnx.py
@@ -1,0 +1,130 @@
+import cv2
+import argparse
+import numpy as np
+import torch
+import utils
+import onnxruntime as ort
+
+
+def single_inference(onnx_session: ort.InferenceSession, image_dict, post_process=False):
+    image, mask = image_dict['image'], image_dict['mask']
+    alpha_shape = image_dict['alpha_shape']
+    alpha_pred_os1, alpha_pred_os4, alpha_pred_os8 = onnx_session.run(
+        None, input_feed={"image": image, "mask": mask})
+    ### refinement
+    alpha_pred_os1, alpha_pred_os4, alpha_pred_os8 = \
+        torch.from_numpy(alpha_pred_os1), \
+        torch.from_numpy(alpha_pred_os4), \
+        torch.from_numpy(alpha_pred_os8)
+
+    # alpha_pred = alpha_pred_os1.clone()
+    alpha_pred = alpha_pred_os8.clone()
+    weight_os4 = utils.get_unknown_tensor_from_pred(alpha_pred,
+                                                    rand_width=30,
+                                                    train_mode=False)
+    alpha_pred[weight_os4 > 0] = alpha_pred_os4[weight_os4 > 0]
+    weight_os1 = utils.get_unknown_tensor_from_pred(alpha_pred,
+                                                    rand_width=15,
+                                                    train_mode=False)
+    alpha_pred[weight_os1 > 0] = alpha_pred_os1[weight_os1 > 0]
+
+    h, w = alpha_shape
+    alpha_pred = alpha_pred[0, 0, ...].data.cpu().numpy()
+    if post_process:
+        alpha_pred = utils.postprocess(alpha_pred)
+    alpha_pred = alpha_pred * 255
+    alpha_pred = alpha_pred.astype(np.uint8)
+    alpha_pred = alpha_pred[32:h + 32, 32:w + 32]
+
+    return alpha_pred
+
+
+def generator_tensor_dict(image_path, mask_path, args):
+    # read images
+    image = cv2.imread(image_path)
+    mask = cv2.imread(mask_path, 0)
+
+    # to 0~1
+    mask = (mask >= args.guidance_thres).astype(np.float32)  ### only keep FG part of trimap
+
+    # mask = mask.astype(np.float32) / 255.0 ### soft trimap
+
+    sample = {'image': image, 'mask': mask, 'alpha_shape': mask.shape}
+
+    # reshape
+    h, w = sample["alpha_shape"]
+
+    if h % 32 == 0 and w % 32 == 0:
+        padded_image = np.pad(sample['image'], ((32, 32), (32, 32), (0, 0)), mode="reflect")
+        padded_mask = np.pad(sample['mask'], ((32, 32), (32, 32)), mode="reflect")
+        sample['image'] = padded_image
+        sample['mask'] = padded_mask
+    else:
+        target_h = 32 * ((h - 1) // 32 + 1)
+        target_w = 32 * ((w - 1) // 32 + 1)
+        pad_h = target_h - h
+        pad_w = target_w - w
+        padded_image = np.pad(sample['image'], ((32, pad_h + 32), (32, pad_w + 32), (0, 0)), mode="reflect")
+        padded_mask = np.pad(sample['mask'], ((32, pad_h + 32), (32, pad_w + 32)), mode="reflect")
+        sample['image'] = padded_image
+        sample['mask'] = padded_mask
+
+    # ImageNet mean & std
+    mean = torch.tensor([0.485, 0.456, 0.406]).view(3, 1, 1)
+    std = torch.tensor([0.229, 0.224, 0.225]).view(3, 1, 1)
+    # convert GBR images to RGB
+    image, mask = sample['image'][:, :, ::-1], sample['mask']
+    # swap color axis
+    image = image.transpose((2, 0, 1)).astype(np.float32)
+
+    mask = np.expand_dims(mask.astype(np.float32), axis=0)
+
+    # normalize image
+    image /= 255.
+
+    # to tensor
+    sample['image'], sample['mask'] = torch.from_numpy(image), torch.from_numpy(mask)
+    sample['image'] = sample['image'].sub_(mean).div_(std)
+
+    # add first channel
+    sample['image'], sample['mask'] = sample['image'][None, ...], sample['mask'][None, ...]
+
+    sample['image'], sample['mask'] = sample['image'].cpu().numpy(), sample['mask'].cpu().numpy()
+
+    print(sample["mask"].min(), sample["mask"].max())  # 0, 1.
+
+    return sample
+
+
+if __name__ == '__main__':
+    print('ONNXRuntime Version: ', ort.__version__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--onnx', type=str, default='./checkpoints/MGMatting-DIM-100k/latest_model.onnx',
+                        help="path of onnx model")
+    parser.add_argument('--image_path', type=str, default='./test_input.jpg', help="input image path")
+    parser.add_argument('--mask_path', type=str, default='./test_mask.png', help="input mask path")
+    parser.add_argument('--output_path', type=str, default='./test_onnx_output.jpg', help="output path")
+    parser.add_argument('--guidance-thres', type=int, default=128, help="guidance input threshold")
+    parser.add_argument('--post-process', action='store_true', default=False,
+                        help='post process to keep the largest connected component')
+
+    # Parse configuration
+    args = parser.parse_args()
+    print(args)
+
+    onnx_session = ort.InferenceSession(args.onnx)
+    print(f"Load {args.onnx} Done!")
+
+    # assume image and mask have the same file name
+    print(f'Image: {args.image_path}\n', f'Mask: {args.mask_path}')
+    image_dict = generator_tensor_dict(args.image_path, args.mask_path, args)
+
+    alpha_pred = single_inference(onnx_session, image_dict, post_process=args.post_process)
+
+    cv2.imwrite(args.output_path, alpha_pred)
+    print(f"Inference ONNX Done! Saved to {args.output_path} !")
+
+    """
+    PYTHONPATH=. python3 ./infer_onnx.py --post-process --onnx ./checkpoints/MGMatting-DIM-100k/latest_model.onnx --image_path ./test_input.jpg --mask_path test_mask.png --output_path ./test_onnx_output.jpg 
+    """

--- a/code-base/networks/decoders/res_shortcut_dec.py
+++ b/code-base/networks/decoders/res_shortcut_dec.py
@@ -32,9 +32,11 @@ class ResShortCut_D_Dec(ResNet_D_Dec):
         x_os4 = (torch.tanh(x_os4) + 1.0) / 2.0
         x_os8 = (torch.tanh(x_os8) + 1.0) / 2.0
 
-        ret['alpha_os1'] = x_os1
-        ret['alpha_os4'] = x_os4
-        ret['alpha_os8'] = x_os8
-
-        return ret
+        if torch.onnx.is_in_onnx_export():
+            return x_os1, x_os4, x_os8
+        else:
+            ret['alpha_os1'] = x_os1
+            ret['alpha_os4'] = x_os4
+            ret['alpha_os8'] = x_os8
+            return ret
 

--- a/code-base/utils/util.py
+++ b/code-base/utils/util.py
@@ -242,6 +242,9 @@ def get_unknown_tensor_from_pred(pred, rand_width=30, train_mode=True):
 
     weight = np.zeros_like(uncertain_area)
     weight[uncertain_area == 1] = 1
-    weight = torch.from_numpy(weight).cuda()
+    if torch.cuda.is_available():
+        weight = torch.from_numpy(weight).cuda()
+    else:
+        weight = torch.from_numpy(weight).cpu()
 
     return weight


### PR DESCRIPTION
Features:
* export_onnx.py to export dynamic and static onnx files.
* infer_onnx.py, test demo.
* C++ inference for MGMatting

export onnx:
```shell
# cd to code-base, then run
PYTHONPATH=. python3 ./export_onnx.py --dynamic --simplify --config ./config/MGMatting-DIM-100k.toml --checkpoint ./checkpoints/MGMatting-DIM-100k/latest_model.pth --output_path ./checkpoints/MGMatting-DIM-100k/latest_model.onnx
```  
log:  
```shell
Torch Version:  1.8.1 ONNX Version:  1.8.0
Namespace(checkpoint='./checkpoints/MGMatting-DIM-100k/latest_model.pth', config='./config/MGMatting-DIM-100k.toml', dynamic=True, output_path='./checkpoints/MGMatting-DIM-100k/latest_model.onnx', simplify=True)
Generate Model Done.
Load ./checkpoints/MGMatting-DIM-100k/latest_model.pth Done.
Export the dynamic onnx model ...
export onnx done.
graph torch-jit-export (
  %image[FLOAT, 1x3xheightxwidth]
  %mask[FLOAT, 1x1xheightxwidth]
) initializers (
  %encoder.conv1.module.weight_u[FLOAT, 32]
...
export onnx sim done.
NodeArg(name='image', type='tensor(float)', shape=[1, 3, 'height', 'width'])
NodeArg(name='mask', type='tensor(float)', shape=[1, 1, 'height', 'width'])
NodeArg(name='alpha_os1', type='tensor(float)', shape=[1, 1, None, None])
NodeArg(name='alpha_os4', type='tensor(float)', shape=[1, 1, None, None])
NodeArg(name='alpha_os8', type='tensor(float)', shape=[1, 1, None, None])
``` 
infer_onnx  
```shell
PYTHONPATH=. python3 ./infer_onnx.py --post-process --onnx ./checkpoints/MGMatting-DIM-100k/latest_model.onnx --image_path ./test_input.jpg --mask_path test_mask.png --output_path ./test_onnx_output.jpg
```
log:
```shell
ONNXRuntime Version:  1.7.0
Namespace(guidance_thres=128, image_path='./test_input.jpg', mask_path='test_mask.png', onnx='./checkpoints/MGMatting-DIM-100k/latest_model.onnx', output_path='./test_onnx_output.jpg', post_process=True)
Load ./checkpoints/MGMatting-DIM-100k/latest_model.onnx Done!
Image: ./test_input.jpg
 Mask: test_mask.png
0.0 1.0
Inference ONNX Done! Saved to ./test_onnx_output.jpg !
```  
the output is:  
![test_input](https://user-images.githubusercontent.com/31974251/145847986-6b2af4c8-aaef-4458-b918-9bb2a0929c49.jpg)
![test_mask](https://user-images.githubusercontent.com/31974251/145847994-c1f9f8a1-36d0-4c14-9e9f-98e8a7581c5c.png)
![test_onnx_output](https://user-images.githubusercontent.com/31974251/145847997-6c2f00ec-4d06-4194-8dad-3df8aa5d00e5.jpg)

@yucornetto 